### PR TITLE
MOBILE-7037: Update mockito dependency

### DIFF
--- a/PrebidMobile/PrebidMobile-rendering/build.gradle
+++ b/PrebidMobile/PrebidMobile-rendering/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'junit:junit:4.12'
 
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.mockito:mockito-core:2.7.22'
 
     testImplementation 'org.json:json:20180813'
     testImplementation 'com.google.code.gson:gson:2.8.6'

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/data/ntv/NativeAdTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/data/ntv/NativeAdTest.java
@@ -220,7 +220,7 @@ public class NativeAdTest {
 
     private void mockClickListener(View clickViewToMock, View onClickParam) {
         doAnswer(invocation -> {
-            final View.OnClickListener listener = invocation.getArgumentAt(0, View.OnClickListener.class);
+            final View.OnClickListener listener = invocation.getArgument(0);
             listener.onClick(onClickParam);
             return null;
         }).when(clickViewToMock).setOnClickListener(any());
@@ -228,7 +228,7 @@ public class NativeAdTest {
 
     private void prepareIntentVerifyUrl(Context spyContext, NativeAdLink nativeAdLink) {
         doAnswer(invocation -> {
-            final Intent intent = invocation.getArgumentAt(0, Intent.class);
+            final Intent intent = invocation.getArgument(0);
             final String url = intent.getStringExtra(EXTRA_URL);
             assertEquals(nativeAdLink.getUrl(), url);
             return null;

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/interstitial/AdBaseDialogTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/interstitial/AdBaseDialogTest.java
@@ -142,7 +142,7 @@ public class AdBaseDialogTest {
 
     private Answer<Object> prepareHandlerAnswer(final String jsonString) {
         return invocation -> {
-            Handler handler = invocation.getArgumentAt(0, Handler.class);
+            Handler handler = invocation.getArgument(0);
             Message message = new Message();
 
             Bundle data = new Bundle();

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/loading/TransactionTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/loading/TransactionTest.java
@@ -191,6 +191,7 @@ public class TransactionTest {
         CreativeModelsMaker.Result result = new CreativeModelsMaker.Result();
         result.creativeModels = creativeModels;
         result.transactionState = state;
+        result.loaderIdentifier = "123";
         return result;
     }
 }

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/CreativeModelMakerBidsTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/CreativeModelMakerBidsTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -48,13 +47,13 @@ public class CreativeModelMakerBidsTest {
     @Test
     public void whenMakeModelsAndNoAdConfiguration_CallErrorListener() {
         mModelMakerBids.makeModels(null, mock(BidResponse.class));
-        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), anyString());
+        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), any());
     }
 
     @Test
     public void whenMakeModelsAndNoBidResponse_CallErrorListener() {
         mModelMakerBids.makeModels(mock(AdConfiguration.class), null);
-        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), anyString());
+        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), any());
     }
 
     @Test
@@ -62,7 +61,7 @@ public class CreativeModelMakerBidsTest {
         BidResponse mockResponse = mock(BidResponse.class);
         when(mockResponse.hasParseError()).thenReturn(true);
         mModelMakerBids.makeModels(null, mockResponse);
-        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), anyString());
+        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), any());
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/CreativeModelsMakerVastTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/CreativeModelsMakerVastTest.java
@@ -34,7 +34,6 @@ import okhttp3.mockwebserver.MockWebServer;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -71,7 +70,7 @@ public class CreativeModelsMakerVastTest {
 
         // Null ad configuration
         creativeModelsMakerVast.makeModels(null, rootParser, latestParser);
-        verify(mMockListener).onFailedToLoadAd(any(AdException.class), anyString());
+        verify(mMockListener).onFailedToLoadAd(any(AdException.class), any());
 
         // Valid - Inline
         creativeModelsMakerVast.makeModels(mAdConfiguration, rootParser, latestParser);

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/CreativeVisibilityTrackerTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/CreativeVisibilityTrackerTest.java
@@ -314,7 +314,7 @@ public class CreativeVisibilityTrackerTest {
         when(mMockView.getParent()).thenReturn(mockParent);
         when(mMockView.getContext()).thenReturn(mActivity);
         doAnswer(invocation -> {
-            final Rect clipRect = invocation.getArgumentAt(0, Rect.class);
+            final Rect clipRect = invocation.getArgument(0);
             clipRect.right = 200;
             clipRect.bottom = 300;
             return true;

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/HTMLCreativeTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/models/HTMLCreativeTest.java
@@ -14,7 +14,6 @@ import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.rendering.errors.AdException;
 import org.prebid.mobile.rendering.listeners.CreativeResolutionListener;
 import org.prebid.mobile.rendering.listeners.CreativeViewListener;
-import org.prebid.mobile.rendering.listeners.VideoCreativeViewListener;
 import org.prebid.mobile.rendering.models.internal.InternalFriendlyObstruction;
 import org.prebid.mobile.rendering.models.internal.MraidEvent;
 import org.prebid.mobile.rendering.models.internal.VisibilityTrackerResult;
@@ -115,7 +114,7 @@ public class HTMLCreativeTest {
 
         ViewPool mockViewPool = mock(ViewPool.class);
         when(mockViewPool.getUnoccupiedView(any(Context.class),
-                                            any(VideoCreativeViewListener.class),
+                                            any(),
                                             any(AdConfiguration.AdUnitIdentifierType.class),
                                             any(InterstitialManager.class)))
             .thenReturn(mockPrebidWebViewBanner);
@@ -155,7 +154,7 @@ public class HTMLCreativeTest {
 
         mHtmlCreative = new HTMLCreative(mContext, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
         mHtmlCreative.load();
-        verify(mockPrebidWebViewBanner).loadHTML(anyString(), anyInt(), anyInt());
+        verify(mockPrebidWebViewBanner).loadHTML(any(), anyInt(), anyInt());
         assertEquals(mockPrebidWebViewBanner, mHtmlCreative.getCreativeView());
     }
 
@@ -249,7 +248,7 @@ public class HTMLCreativeTest {
 
         doAnswer(invocation -> {
             CreativeVisibilityTracker.VisibilityTrackerListener listener =
-                invocation.getArgumentAt(0, CreativeVisibilityTracker.VisibilityTrackerListener.class);
+                invocation.getArgument(0);
 
             listener.onVisibilityChanged(result);
             return null;
@@ -337,7 +336,7 @@ public class HTMLCreativeTest {
         verify(mMockMraidController).handleMraidEvent(any(MraidEvent.class),
                                                       eq(mHtmlCreative),
                                                       any(WebViewBase.class),
-                                                      any(PrebidWebViewBase.class));
+                                                      any());
     }
 
     @Test
@@ -358,7 +357,7 @@ public class HTMLCreativeTest {
         mHtmlCreative.setCreativeView(mockOXWebView);
 
         mHtmlCreative.createOmAdSession();
-        verify(mMockOmAdSessionManager).initWebAdSessionManager(any(WebViewBase.class), anyString());
+        verify(mMockOmAdSessionManager).initWebAdSessionManager(any(WebViewBase.class), any());
         verify(mMockOmAdSessionManager).registerAdView(any(View.class));
         verify(mMockOmAdSessionManager).startAdSession();
 

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidCloseTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidCloseTest.java
@@ -87,7 +87,7 @@ public class MraidCloseTest {
         mraidVariableContainer.setCurrentState(JSInterface.STATE_EXPANDED);
         mMraidClose.closeThroughJS();
         verify(mSpyBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
-        verify(mockViewGroup).removeView(any(View.class));
+        verify(mockViewGroup).removeView(any());
 
         reset(mSpyBaseJSInterface);
         AdBrowserActivity mockActivity = new AdBrowserActivity();

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidExpandTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidExpandTest.java
@@ -61,7 +61,7 @@ public class MraidExpandTest {
     public void expandTest() {
 
         doAnswer(invocation -> {
-            RedirectUrlListener listener = invocation.getArgumentAt(1, RedirectUrlListener.class);
+            RedirectUrlListener listener = invocation.getArgument(1);
             listener.onSuccess("test", "html");
             return null;
         }).when(mSpyBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidResizeTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidResizeTest.java
@@ -74,12 +74,12 @@ public class MraidResizeTest {
         when(mSpyBaseJsInterface.getMraidVariableContainer()).thenReturn(mMockMraidVariableContainer);
 
         when(mMockWebViewBase.post(any(Runnable.class))).thenAnswer(invocation -> {
-            Runnable runnable = invocation.getArgumentAt(0, Runnable.class);
+            Runnable runnable = invocation.getArgument(0);
             runnable.run();
             return null;
         });
         doAnswer(invocation -> {
-            Handler handler = invocation.getArgumentAt(0, Handler.class);
+            Handler handler = invocation.getArgument(0);
             Message message = new Message();
             Bundle data = new Bundle();
             data.putString(JSInterface.JSON_VALUE, "{\"width\":320,\"height\":250,\"customClosePosition\":\"top-right\",\"offsetX\":0,\"offsetY\":0,\"allowOffscreen\":true}");

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidStorePictureTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidStorePictureTest.java
@@ -49,7 +49,7 @@ public class MraidStorePictureTest {
         when(mMockWebViewBase.post(any(Runnable.class))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                Runnable runnable = invocation.getArgumentAt(0, Runnable.class);
+                Runnable runnable = invocation.getArgument(0);
                 runnable.run();
                 return null;
             }

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidUrlHandlerTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidUrlHandlerTest.java
@@ -53,8 +53,8 @@ public class MraidUrlHandlerTest {
     public void openTest() {
 
         doAnswer(invocation -> {
-            RedirectUrlListener listener = invocation.getArgumentAt(1, RedirectUrlListener.class);
-            listener.onSuccess(invocation.getArgumentAt(0, String.class), "html");
+            RedirectUrlListener listener = invocation.getArgument(1);
+            listener.onSuccess(invocation.getArgument(0), "html");
 
             return null;
         }).when(mMockBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequesterTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequesterTest.java
@@ -16,8 +16,8 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -48,7 +48,7 @@ public class BidRequesterTest {
         mAdConfiguration.setConfigId("test");
         BidRequester requester = new BidRequester(null, mAdConfiguration, mAdRequestInput, mMockResponseHandler);
         requester.startAdRequest();
-        verify(mMockResponseHandler).onErrorWithException(any(AdException.class), anyInt());
+        verify(mMockResponseHandler).onErrorWithException(any(AdException.class), anyLong());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class BidRequesterTest {
         mAdConfiguration.setConfigId(null);
         BidRequester requester = new BidRequester(mContext, mAdConfiguration, mAdRequestInput, mMockResponseHandler);
         requester.startAdRequest();
-        verify(mMockResponseHandler).onError(anyString(), anyInt());
+        verify(mMockResponseHandler).onError(anyString(), anyLong());
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeTest.java
@@ -15,7 +15,6 @@ import org.prebid.mobile.rendering.models.AbstractCreative;
 import org.prebid.mobile.rendering.models.AdConfiguration;
 import org.prebid.mobile.rendering.models.internal.InternalPlayerState;
 import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
-import org.prebid.mobile.rendering.video.vast.AdVerifications;
 import org.prebid.mobile.rendering.views.interstitial.InterstitialManager;
 import org.prebid.mobile.test.utils.WhiteBox;
 import org.robolectric.Robolectric;
@@ -24,8 +23,7 @@ import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -74,7 +72,7 @@ public class VideoCreativeTest {
 
         spyVideoCreative.display();
 
-        verify(mVideoCreative.mVideoCreativeView).start(anyInt());
+        verify(mVideoCreative.mVideoCreativeView).start(anyFloat());
     }
 
     @Test
@@ -84,7 +82,7 @@ public class VideoCreativeTest {
 
         spyVideoCreative.createOmAdSession();
 
-        verify(mMockOmAdSessionManager).initVideoAdSession(any(AdVerifications.class), anyString());
+        verify(mMockOmAdSessionManager).initVideoAdSession(any(), any());
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeViewTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeViewTest.java
@@ -14,6 +14,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -39,7 +40,7 @@ public class VideoCreativeViewTest {
         WhiteBox.field(VideoCreativeView.class, "mExoPlayerView").set(mVideoCreativeView, mockPlugPlayView);
 
         mVideoCreativeView.start(anyInt());
-        verify(mockPlugPlayView).start(anyInt());
+        verify(mockPlugPlayView).start(anyFloat());
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/AdViewManagerTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/AdViewManagerTest.java
@@ -345,7 +345,7 @@ public class AdViewManagerTest {
         verify(mockAdView, never()).removeView(any(View.class));
         WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
         mAdViewManager.hide();
-        verify(mockAdView).removeView(any(View.class));
+        verify(mockAdView).removeView(any());
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialManagerTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialManagerTest.java
@@ -218,7 +218,7 @@ public class InterstitialManagerTest {
 
     @Test
     public void interstitialDialogShown_NotifyInterstitialDelegate() {
-        mSpyInterstitialManager.interstitialDialogShown(any(ViewGroup.class));
+        mSpyInterstitialManager.interstitialDialogShown(mock(ViewGroup.class));
 
         verify(mMockInterstitialManagerDisplayDelegate).interstitialDialogShown(any(ViewGroup.class));
     }

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideoTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideoTest.java
@@ -57,7 +57,7 @@ public class InterstitialVideoTest {
         mSpyInterstitialVideo = Mockito.spy(new InterstitialVideo(null, mMockAdView, mMockInterstitialManager, mMockAdConfiguration));
 
         doAnswer(invocation -> {
-            Runnable runnable = invocation.getArgumentAt(0, Runnable.class);
+            Runnable runnable = invocation.getArgument(0);
             runnable.run();
             return null;
         }).when(mMockHandler).post(any(Runnable.class));

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBannerTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBannerTest.java
@@ -76,7 +76,7 @@ public class PrebidWebViewBannerTest {
     throws IllegalAccessException {
         final String jsonAnswer = "{\"width\":100,\"height\":200,\"useCustomClose\":false,\"isModal\":true}";
         doAnswer(invocation -> {
-            Handler handler = invocation.getArgumentAt(0, Handler.class);
+            Handler handler = invocation.getArgument(0);
             Message message = new Message();
 
             Bundle data = new Bundle();

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBaseTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBaseTest.java
@@ -116,7 +116,8 @@ public class PrebidWebViewBaseTest {
         when(mockHandler.postDelayed(any(Runnable.class), anyLong())).thenAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) {
-                invocation.getArgumentAt(0, Runnable.class).run();
+                Runnable runnable = invocation.getArgument(0);
+                runnable.run();
                 return null;
             }
         });

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/BaseJSInterfaceTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/BaseJSInterfaceTest.java
@@ -100,7 +100,7 @@ public class BaseJSInterfaceTest {
 
         Mockito.when(mMockWebViewBase.post(Mockito.any(Runnable.class))).thenAnswer(
             invocation -> {
-                Runnable runnable = invocation.getArgumentAt(0, Runnable.class);
+                Runnable runnable = invocation.getArgument(0);
                 if (runnable != null) {
                     runnable.run();
                 }
@@ -178,7 +178,7 @@ public class BaseJSInterfaceTest {
         assertEquals(JSInterface.ACTION_ORIENTATION_CHANGE, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -190,7 +190,7 @@ public class BaseJSInterfaceTest {
 
         assertEquals(JSInterface.ACTION_CLOSE, event.mraidAction);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -202,7 +202,7 @@ public class BaseJSInterfaceTest {
 
         assertEquals(JSInterface.ACTION_RESIZE, event.mraidAction);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -215,7 +215,7 @@ public class BaseJSInterfaceTest {
         assertEquals(JSInterface.ACTION_EXPAND, event.mraidAction);
         assertNull(event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -227,7 +227,7 @@ public class BaseJSInterfaceTest {
 
         assertEquals(JSInterface.ACTION_EXPAND, event.mraidAction);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -241,7 +241,7 @@ public class BaseJSInterfaceTest {
         assertEquals(JSInterface.ACTION_OPEN, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -254,7 +254,7 @@ public class BaseJSInterfaceTest {
         assertEquals(JSInterface.ACTION_CREATE_CALENDAR_EVENT, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -267,7 +267,7 @@ public class BaseJSInterfaceTest {
         assertEquals(JSInterface.ACTION_STORE_PICTURE, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -280,7 +280,7 @@ public class BaseJSInterfaceTest {
         assertEquals(JSInterface.ACTION_PLAY_VIDEO, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any(PrebidWebViewBase.class));
+        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
     }
 
     @Test
@@ -328,7 +328,7 @@ public class BaseJSInterfaceTest {
         assertEquals("{\"x\":0,\"width\":0,\"y\":0,\"height\":0}", currentPosition);
 
         when(mMockWebViewBase.getGlobalVisibleRect(any(Rect.class))).then(invocation -> {
-            Rect argumentRect = invocation.getArgumentAt(0, Rect.class);
+            Rect argumentRect = invocation.getArgument(0);
             argumentRect.left = 1;
             argumentRect.top = 2;
             argumentRect.right = 3;
@@ -362,7 +362,7 @@ public class BaseJSInterfaceTest {
         Shadows.shadowOf(Looper.getMainLooper()).idle();
 
         verify(mSpyBaseJSInterface, timeout(100)).updateScreenMetricsAsync(any(Runnable.class));
-        verify(mSpyBaseJSInterface).supports(anyString());
+        verify(mSpyBaseJSInterface).supports(any());
         verify(mMockJsExecutor).executeOnReadyExpanded();
     }
 
@@ -405,7 +405,7 @@ public class BaseJSInterfaceTest {
         ResponseHandler getOriginalURLCallBack = WhiteBox.getInternalState(oxmRedirectedUrlAsyncTask, "mResponseHandler");
 
         getOriginalURLCallBack.onResponse(mock(BaseNetworkTask.GetUrlResult.class));
-        verify(mockListener).onSuccess(anyString(), anyString());
+        verify(mockListener).onSuccess(any(), any());
 
         getOriginalURLCallBack.onResponse(null);
         verify(mockListener).onFailed();


### PR DESCRIPTION
refactoring(Mockito):
- Update mockito version and applied changes for tests. Mockito version is now consistent with version used in prebid.

NOTE: TestUtils module was not removed due to absence of alternative solution in mockito. Features of our TestUtils modules were present in mockito version before 2.2 (currently used is 2.7). So for now I suggest us to stick with our TestUtils module.