### PR TITLE
MOBILE-7049: Sync support of GDPR and CCPA

### DIFF
--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilder.java
@@ -17,7 +17,6 @@
 package org.prebid.mobile.rendering.networking.parameters;
 
 import org.prebid.mobile.rendering.models.openrtb.BidRequest;
-import org.prebid.mobile.rendering.sdk.ManagersResolver;
 import org.prebid.mobile.rendering.sdk.deviceData.managers.UserConsentManager;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
 
@@ -27,10 +26,10 @@ public class UserConsentParameterBuilder extends ParameterBuilder {
     private static final String US_PRIVACY = "us_privacy";
     private static final String CONSENT = "consent";
 
-    private UserConsentManager mUserConsentManager;
+    private final UserConsentManager mUserConsentManager;
 
-    public UserConsentParameterBuilder() {
-        mUserConsentManager = ManagersResolver.getInstance().getUserConsentManager();
+    public UserConsentParameterBuilder(UserConsentManager userConsentManager) {
+        mUserConsentManager = userConsentManager;
     }
 
     @Override

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/utils/helpers/AdIdManager.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/utils/helpers/AdIdManager.java
@@ -92,7 +92,6 @@ public class AdIdManager {
         sLimitAdTrackingEnabled = limitAdTrackingEnabled;
     }
 
-    @VisibleForTesting
     public static void setAdId(String adId) {
         sAdId = adId;
     }

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequesterTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequesterTest.java
@@ -28,6 +28,7 @@ import org.prebid.mobile.rendering.errors.AdException;
 import org.prebid.mobile.rendering.models.AdConfiguration;
 import org.prebid.mobile.rendering.networking.ResponseHandler;
 import org.prebid.mobile.rendering.networking.parameters.AdRequestInput;
+import org.prebid.mobile.rendering.sdk.ManagersResolver;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -57,6 +58,7 @@ public class BidRequesterTest {
         mContext = Robolectric.buildActivity(Activity.class).create().get();
         mAdConfiguration = new AdConfiguration();
         mAdRequestInput = new AdRequestInput();
+        ManagersResolver.getInstance().prepare(mContext);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilderTest.java
@@ -44,7 +44,7 @@ public class UserConsentParameterBuilderTest {
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(robolectricActivity);
         mSharedPreferences.edit().putString("IABConsent_ConsentString", "foobar_consent_string").commit();
 
-        mBuilder = new UserConsentParameterBuilder();
+        mBuilder = new UserConsentParameterBuilder(ManagersResolver.getInstance().getUserConsentManager());
     }
 
     @Test


### PR DESCRIPTION
feat(UserConsentManager):
- Added handling of device purpose consent
- Cleanup unused variables

feat(Requester):
- Fetching ADID only if device consent is valid
- Nullifying ADID if consent is not granted (in case it changed)

tests(unit):
- Added unit tests to verify consent behaviour