### PR TITLE
MOBILE-7056: Introduce rendering module as part of Prebid

### DIFF
--- a/PrebidMobile/PrebidMobile-gamEventHandlers/build.gradle
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/build.gradle
@@ -14,33 +14,10 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.library'
+apply from: '../shared-rendering.gradle'
+apply from: 'publish-handlers.gradle'
 
 android {
-    compileSdkVersion 30
-
-    defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0.0"
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        testOptions {
-            unitTests {
-                includeAndroidResources true
-                returnDefaultValues = true
-            }
-        }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/INDEX.LIST'
-        exclude 'META-INF/LICENSE'
-    }
-
     buildTypes {
         release {
             minifyEnabled true
@@ -50,12 +27,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
 }
 
 dependencies {
@@ -65,10 +36,6 @@ dependencies {
 
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'junit:junit:4.12'
-    testImplementation project(':TestUtils')
 
     testImplementation 'org.mockito:mockito-core:1.10.19'
 }
-
-sourceCompatibility = "8"
-targetCompatibility = "8"

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/publish-handlers.gradle
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/publish-handlers.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'maven-publish'
+
+def ARTIFACT_ID = "prebid-mobile-sdk-gamEventHandlers"
+
+publishing {
+    publications {
+        eventHandler(MavenPublication) {
+            artifactId "$ARTIFACT_ID"
+            artifact "${project.buildDir}/outputs/aar/${project.name}-release.aar"
+            version "$prebidVersionName"
+            groupId "$artifactGroupId"
+        }
+    }
+
+    // Using local repository for generated artifacts.
+    repositories {
+        maven {
+            name = 'LocalArtifacts'
+            url = "file://$artifactFolder"
+        }
+    }
+}
+

--- a/PrebidMobile/PrebidMobile-mopubAdapters/build.gradle
+++ b/PrebidMobile/PrebidMobile-mopubAdapters/build.gradle
@@ -14,18 +14,12 @@
  *    limitations under the License.
  */
 
-apply plugin: 'com.android.library'
+apply from: '../shared-rendering.gradle'
+apply from: 'publish-adapters.gradle'
 
 android {
-    compileSdkVersion 30
-
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0.0"
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -40,17 +34,6 @@ android {
             includeAndroidResources = true
         }
     }
-
-    packagingOptions {
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/INDEX.LIST'
-        exclude 'META-INF/LICENSE'
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
 }
 
 dependencies {
@@ -64,5 +47,4 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.7.7'
-    testImplementation project(path: ':TestUtils')
 }

--- a/PrebidMobile/PrebidMobile-mopubAdapters/publish-adapters.gradle
+++ b/PrebidMobile/PrebidMobile-mopubAdapters/publish-adapters.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'maven-publish'
+
+def ARTIFACT_ID = "prebid-mobile-sdk-mopubAdapters"
+
+publishing {
+    publications {
+        mopubAdapter(MavenPublication) {
+            artifactId "$ARTIFACT_ID"
+            artifact "${project.buildDir}/outputs/aar/${project.name}-release.aar"
+            version "$prebidVersionName"
+            groupId "$artifactGroupId"
+        }
+    }
+
+    // Using local repository for generated artifacts.
+    repositories {
+        maven {
+            name = 'LocalArtifacts'
+            url = "file://$artifactFolder"
+        }
+    }
+}
+

--- a/PrebidMobile/PrebidMobile-rendering/build.gradle
+++ b/PrebidMobile/PrebidMobile-rendering/build.gradle
@@ -13,8 +13,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-apply plugin: 'com.android.library'
+apply from: '../shared-rendering.gradle'
+apply from: 'publish-rendering-sdk.gradle'
+apply from: 'publish-omsdk.gradle'
 
 android {
     def getGitHash = { ->
@@ -26,27 +27,8 @@ android {
         return stdout.toString().trim()
     }
 
-    compileSdkVersion 30
-
-    packagingOptions {
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/INDEX.LIST'
-        exclude 'META-INF/LICENSE'
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         buildConfigField "String", "GitHash", "\"${getGitHash()}\""
-
-        minSdkVersion 16
-        targetSdkVersion 30
-        versionCode 1
-        versionName prebidVersionName
-
         buildConfigField "String", "VERSION", "\"${versionName}\""
     }
 
@@ -56,7 +38,6 @@ android {
     }
 
     buildTypes {
-
         debug {
             minifyEnabled false
         }
@@ -67,10 +48,6 @@ android {
     }
 
     testOptions {
-        unitTests {
-            includeAndroidResources = true
-            returnDefaultValues = true
-        }
         unitTests.all {
             testLogging {
                 exceptionFormat = "full"
@@ -91,8 +68,6 @@ dependencies {
     testImplementation 'org.json:json:20180813'
     testImplementation 'com.google.code.gson:gson:2.8.6'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
-
-    testImplementation project(':TestUtils')
 
     // Google play services
     implementation 'com.google.android.gms:play-services-base:17.6.0'

--- a/PrebidMobile/PrebidMobile-rendering/publish-omsdk.gradle
+++ b/PrebidMobile/PrebidMobile-rendering/publish-omsdk.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'maven-publish'
+
+def ARCHIVE_NAME = "${omSdkModuleName}-${omSdkVersion}"
+
+publishing {
+    publications {
+        omsdk(MavenPublication) {
+            artifactId "${omSdkModuleName}"
+            artifact "${project.rootDir}/PrebidMobile/${omSdkModuleName}/${ARCHIVE_NAME}.aar"
+            version "$omSdkVersion"
+            groupId "$artifactGroupId"
+        }
+    }
+}

--- a/PrebidMobile/PrebidMobile-rendering/publish-rendering-sdk.gradle
+++ b/PrebidMobile/PrebidMobile-rendering/publish-rendering-sdk.gradle
@@ -1,0 +1,45 @@
+apply plugin: 'maven-publish'
+
+def ARTIFACT_ID = "prebid-mobile-sdk-rendering"
+def ARCHIVE_NAME = "PrebidMobile-rendering-release"
+
+publishing {
+    publications {
+        renderingSdk(MavenPublication) {
+            artifactId ARTIFACT_ID
+            artifact "${project.buildDir}/outputs/aar/${ARCHIVE_NAME}.aar"
+            version "${prebidVersionName}"
+            groupId "${artifactGroupId}"
+
+            //The publication doesn't know about our dependencies, so we have to manually add them to the pom
+            pom.withXml {
+                // for dependencies and exclusions
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.implementation.allDependencies.withType(ModuleDependency) { ModuleDependency dp ->
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', dp.group)
+                    dependencyNode.appendNode('artifactId', dp.name)
+                    dependencyNode.appendNode('version', dp.version)
+
+                    // for exclusions
+                    if (dp.excludeRules.size() > 0) {
+                        def exclusions = dependencyNode.appendNode('exclusions')
+                        dp.excludeRules.each { ExcludeRule ex ->
+                            def exclusion = exclusions.appendNode('exclusion')
+                            exclusion.appendNode('groupId', ex.group)
+                            exclusion.appendNode('artifactId', ex.module)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Using local repository for generated artifacts.
+    repositories {
+        maven {
+            name = 'LocalArtifacts'
+            url = "file://$artifactFolder"
+        }
+    }
+}

--- a/PrebidMobile/omsdk-android/build.gradle
+++ b/PrebidMobile/omsdk-android/build.gradle
@@ -1,2 +1,5 @@
 configurations.maybeCreate("default")
-artifacts.add("default", file('omsdk-android-1.3.17.aar'))
+artifacts.add("default", file("${omSdkModuleName}-${omSdkVersion}.aar"))
+
+setGroup("${artifactGroupId}")
+setVersion("${omSdkVersion}")

--- a/PrebidMobile/shared-rendering.gradle
+++ b/PrebidMobile/shared-rendering.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion rootProject.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.minSDKVersion
+        targetSdkVersion rootProject.targetSDKVersion
+        versionCode rootProject.prebidVersionCode
+        versionName rootProject.prebidVersionName
+    }
+
+    packagingOptions {
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/INDEX.LIST'
+        exclude 'META-INF/LICENSE'
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources true
+            returnDefaultValues = true
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    testImplementation project(':TestUtils')
+}
+
+task javadoc(type: Javadoc) {
+    failOnError false
+
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+
+    options.addStringOption('Xdoclint:none', '-quiet')
+    options.addStringOption('encoding', 'UTF-8')
+    options.addStringOption('charSet', 'UTF-8')
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set("javadoc")
+    from javadoc.destinationDir
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier.set("sources")
+    from android.sourceSets.main.java.srcDirs
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ ext {
     targetSDKVersion = 28
     compileSdkVersion = 30
     buildToolsVersion = "28.0.3"
+
+    artifactGroupId = "org.prebid"
+    artifactFolder = "${buildDir}/generated-artifacts"
+    omSdkVersion = "1.3.17"
+    omSdkModuleName = "omsdk-android"
 }
 
 buildscript {

--- a/scripts/buildPrebidMobileRendering.sh
+++ b/scripts/buildPrebidMobileRendering.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+if [ -d "scripts" ]; then
+  cd scripts/ || true
+fi
+
+set -e
+
+cd ..
+
+# $1 - module name
+function generateArtifacts() {
+  echo "Generating artifacts and javadoc for module: ${1}"
+
+  ./gradlew :"${1}":assemble
+  ./gradlew :"${1}":javadocJar
+  ./gradlew :"${1}":sourcesJar
+}
+
+# $1 - regex, $2 - file to search, $3 createDir
+function findVariableWithRegex() {
+  local foundMatch=""
+
+  while read -r line; do
+    if [[ $line =~ ${1} ]]; then
+      foundMatch=${BASH_REMATCH[1]}
+    fi
+  done <"${2}"
+
+  echo "$foundMatch"
+}
+
+MODULE_NAME_RENDERING_SDK="PrebidMobile-rendering"
+MODULE_NAME_MOPUB="PrebidMobile-mopubAdapters"
+MODULE_NAME_EVENT_HANDLERS="PrebidMobile-gamEventHandlers"
+MODULE_NAME_OM_SDK="omsdk-android"
+
+ARTIFACT_ID_RENDERING_SDK="prebid-mobile-sdk-rendering"
+ARTIFACT_ID_MOPUB_ADAPTERS="prebid-mobile-sdk-mopubAdapters"
+ARTIFACT_ID_GAM_EVENT_HANDLERS="prebid-mobile-sdk-gamEventHandlers"
+
+PATH_BASE="$PWD"
+PATH_BASE_SDK_MODULE="${PATH_BASE}/PrebidMobile"
+PATH_BASE_ARTIFACT="${PATH_BASE}/build/generated-artifacts/org/prebid"
+PATH_OUTPUT="${PATH_BASE}/generated/rendering"
+PATH_LIBS="build/libs"
+
+# set the default release version to what's in the project's build.gradle file
+prebidVersionRegex="prebidVersionName.*=.*\"(.*)\""
+omSdkVersionRegex="omSdkVersion.*=.*\"(.*)\""
+VERSION_RELEASE="$(findVariableWithRegex "${prebidVersionRegex}" "${PATH_BASE}"/build.gradle)"
+VERSION_OM_SDK="$(findVariableWithRegex "${omSdkVersionRegex}" "${PATH_BASE}"/build.gradle)"
+
+echo "Building artifacts for version: [${VERSION_RELEASE}], OM SDK version: [${VERSION_OM_SDK}]"
+
+generateArtifacts ${MODULE_NAME_RENDERING_SDK}
+generateArtifacts ${MODULE_NAME_EVENT_HANDLERS}
+generateArtifacts ${MODULE_NAME_MOPUB}
+
+# Generate and publish .pom (includes previously generated .aar). This step will include OM SDK artifacts local deploy.
+./gradlew publishAllPublicationsToLocalArtifactsRepository
+
+mkdir -p "${PATH_OUTPUT}"
+echo "Moving artifacts to $PATH_OUTPUT"
+
+# Pay attention that for cycle depends on order and element count in moduleArray and artifactIdArray.
+# Modify with caution.
+moduleArray=("${MODULE_NAME_RENDERING_SDK}" "${MODULE_NAME_MOPUB}" "${MODULE_NAME_EVENT_HANDLERS}")
+artifactIdArray=("${ARTIFACT_ID_RENDERING_SDK}" "${ARTIFACT_ID_MOPUB_ADAPTERS}" "${ARTIFACT_ID_GAM_EVENT_HANDLERS}")
+
+for i in "${!moduleArray[@]}"; do
+  moduleName="${moduleArray[i]}"
+  artifactId="${artifactIdArray[i]}"
+
+  echo "Extracting module: [${moduleName}], artifactId: [${artifactId}] for moving .aar, .pom, javadoc and sources into appropriate output folder."
+
+  outputArtifactPath="${PATH_OUTPUT}/${artifactId}"
+  mkdir -p "${outputArtifactPath}"
+
+  # Moves and renames aar and pom files per module to output folder (with artifact id as destinationPath).
+  # Renaming is performed to remove version from pom and aar file names. Example resulting path: %project%/generated/rendering/%artifactId%/%artifactId%.pom
+  mv $"${PATH_BASE_ARTIFACT}/${artifactId}/${VERSION_RELEASE}/${artifactId}-${VERSION_RELEASE}.aar" "${outputArtifactPath}/${artifactId}.aar"
+  mv $"${PATH_BASE_ARTIFACT}/${artifactId}/${VERSION_RELEASE}/${artifactId}-${VERSION_RELEASE}.pom" "${outputArtifactPath}/${artifactId}.pom"
+
+  # Moves and renames generated javadoc per module.
+  mv $"${PATH_BASE_SDK_MODULE}/${moduleName}/${PATH_LIBS}/${moduleName}-javadoc.jar" "${outputArtifactPath}/${artifactId}-javadoc.jar"
+  mv $"${PATH_BASE_SDK_MODULE}/${moduleName}/${PATH_LIBS}/${moduleName}-sources.jar" "${outputArtifactPath}/${artifactId}-sources.jar"
+done
+
+outputArtifactPath="${PATH_OUTPUT}/${MODULE_NAME_OM_SDK}"
+mkdir -p "${outputArtifactPath}"
+
+# Moves OM SDK pom and aar to output folder.
+echo "Extracting module: [OM SDK] for moving .aar and .pom into appropriate output folder."
+
+PATH_OM_SDK_ARTIFACT="${PATH_BASE_ARTIFACT}/${MODULE_NAME_OM_SDK}/${VERSION_OM_SDK}/${MODULE_NAME_OM_SDK}-${VERSION_OM_SDK}"
+mv $"${PATH_OM_SDK_ARTIFACT}.aar" "${outputArtifactPath}/${MODULE_NAME_OM_SDK}.aar"
+mv $"${PATH_OM_SDK_ARTIFACT}.pom" "${outputArtifactPath}/${MODULE_NAME_OM_SDK}.pom"
+
+echo "Done!"
+echo "Files can be found in $PATH_OUTPUT"


### PR DESCRIPTION
feat(gradle.publish):
- Added script to generate OM SDK POM
- Added script to generate MoPub Adapters POM
- Added script to generate GAM EH SDK POM
- Added script to generate rendering SDK POM
- Added shared build script to reduce duplication

feat(gradle):
- Renaming and moving common properties to project ext

feat(deployPrebidMobile):
- Simplifying script by extracting maven publishing into a separate function
- Added artifact generation and moving them to generated folder alongside prebid artifacts

To verify that build script is working you can run the following script:
`./scripts/buildPrebidMobileRendering.sh`
This script will generate artifacts and store them in `generated/rendering` folder. See attached screenshot:
<img width="765" alt="Screenshot 2021-04-27 at 16 20 00" src="https://user-images.githubusercontent.com/79995965/116248922-f4cc3280-a774-11eb-89d6-dbd77685e13c.png">

To verify deploy script go to `scripts` (`cd scripts`) and run `./Maven/deployPrebidMobile.sh`. This script will run `buildPrebidMobile.sh` and `buildPrebidMobileRendering.sh` and will store their output in `Maven/filesToDeploy` folder. See screenshot:
![Screenshot 2021-04-27 at 16 25 43](https://user-images.githubusercontent.com/79995965/116249201-3d83eb80-a775-11eb-8d89-30658218cb4b.png)

**NOTE:** Deploy script will not finish successfully due to actual attempts to deploy through `mvn pgp` command. To test `deployPrebidMobile.sh` script you can comment out the content of `mavenDeploy` function.