### PR TITLE
MOBILE-7080: Sync request params with Prebid

### DIFF
--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
@@ -16,15 +16,19 @@
 
 package org.prebid.mobile.rendering.bidding.data.bid;
 
+import android.text.TextUtils;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.prebid.mobile.rendering.bidding.data.AdSize;
 import org.prebid.mobile.rendering.models.AdConfiguration;
 import org.prebid.mobile.rendering.networking.targeting.Targeting;
+import org.prebid.mobile.rendering.sdk.PrebidRenderingSettings;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import static org.prebid.mobile.rendering.utils.helpers.Utils.addValue;
 
@@ -73,7 +77,7 @@ public class Prebid {
         return prebidObject;
     }
 
-    public static JSONObject getJsonObjectForApp(String sdkName, String sdkVersion){
+    public static JSONObject getJsonObjectForApp(String sdkName, String sdkVersion) {
         JSONObject prebid = new JSONObject();
         Utils.addValue(prebid, "source", sdkName);
         Utils.addValue(prebid, "version", sdkVersion);
@@ -116,7 +120,39 @@ public class Prebid {
         JSONObject prebid = new JSONObject();
         StoredRequest storedRequest = new StoredRequest(configId);
         addValue(prebid, "storedrequest", storedRequest.toJSONObject());
+
+        addStoredAuctionResponse(prebid);
+        addStoredBidResponse(prebid);
+
         return prebid;
+    }
+
+    private static void addStoredAuctionResponse(JSONObject prebid) {
+        final String storedAuctionResponse = PrebidRenderingSettings.getStoredAuctionResponse();
+        if (!TextUtils.isEmpty(storedAuctionResponse)) {
+            JSONObject storedAuctionResponseJson = new JSONObject();
+            Utils.addValue(storedAuctionResponseJson, "id", storedAuctionResponse);
+            Utils.addValue(prebid, "storedauctionresponse", storedAuctionResponseJson);
+        }
+    }
+
+    private static void addStoredBidResponse(JSONObject prebid) {
+        final Map<String, String> storedBidResponseMap = PrebidRenderingSettings.getStoredBidResponseMap();
+        if (!storedBidResponseMap.isEmpty()) {
+            JSONArray bidResponseArray = new JSONArray();
+
+            for (Map.Entry<String, String> entry : storedBidResponseMap.entrySet()) {
+                final String bidder = entry.getKey();
+                final String bidId = entry.getValue();
+                if (!TextUtils.isEmpty(bidder) && !TextUtils.isEmpty(bidId)) {
+                    JSONObject storedBid = new JSONObject();
+                    Utils.addValue(storedBid, "bidder", bidder);
+                    Utils.addValue(storedBid, "id", bidId);
+                }
+            }
+
+            Utils.addValue(prebid, "storedbidresponse", bidResponseArray);
+        }
     }
 
     private static void toHashMap(HashMap<String, String> hashMap, JSONObject jsonObject) {

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/display/BaseAdUnit.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/display/BaseAdUnit.java
@@ -140,6 +140,15 @@ abstract class BaseAdUnit {
         mAdUnitConfig.clearContextKeywords();
     }
 
+    public void setPbAdSlot(String adSlot) {
+        mAdUnitConfig.setPbAdSlot(adSlot);
+    }
+
+    @Nullable
+    public String getPbAdSlot() {
+        return mAdUnitConfig.getPbAdSlot();
+    }
+
     public void destroy() {
         mOnFetchCompleteListener = null;
         mBidLoader.destroy();

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/parallel/BannerView.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/parallel/BannerView.java
@@ -387,6 +387,15 @@ public class BannerView extends FrameLayout {
     public BannerAdPosition getAdPosition() {
         return BannerAdPosition.mapToDisplayAdPosition(mAdUnitConfig.getAdPositionValue());
     }
+
+    public void setPbAdSlot(String adSlot) {
+        mAdUnitConfig.setPbAdSlot(adSlot);
+    }
+
+    @Nullable
+    public String getPbAdSlot() {
+        return mAdUnitConfig.getPbAdSlot();
+    }
     //endregion ==================== getters and setters
 
     private void reflectAttrs(AttributeSet attrs) {

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/parallel/BaseInterstitialAdUnit.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/parallel/BaseInterstitialAdUnit.java
@@ -202,6 +202,15 @@ public abstract class BaseInterstitialAdUnit {
     public void clearContextKeywords() {
         mAdUnitConfig.clearContextKeywords();
     }
+
+    public void setPbAdSlot(String adSlot) {
+        mAdUnitConfig.setPbAdSlot(adSlot);
+    }
+
+    @Nullable
+    public String getPbAdSlot() {
+        return mAdUnitConfig.getPbAdSlot();
+    }
     /// setters and getters end region
 
     /**

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/models/AdConfiguration.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/models/AdConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.prebid.mobile.rendering.models;
 
-import androidx.annotation.Nullable;
-
 import org.prebid.mobile.rendering.bidding.data.AdSize;
 import org.prebid.mobile.rendering.interstitial.InterstitialSizes;
 import org.prebid.mobile.rendering.models.ntv.NativeAdConfiguration;
@@ -30,6 +28,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import androidx.annotation.Nullable;
 
 public class AdConfiguration {
 
@@ -52,6 +52,8 @@ public class AdConfiguration {
     private String mInterstitialSize;
     private String mContentUrl;
     private String mConfigId;
+    @Nullable
+    private String mPbAdSlot;
 
     private boolean mIsRewarded;
     private boolean mIsBuiltInVideo = false;
@@ -228,6 +230,17 @@ public class AdConfiguration {
 
     public void setConfigId(String configId) {
         mConfigId = configId;
+    }
+
+    public void setPbAdSlot(
+        @Nullable
+            String pbAdSlot) {
+        mPbAdSlot = pbAdSlot;
+    }
+
+    @Nullable
+    public String getPbAdSlot() {
+        return mPbAdSlot;
     }
 
     @Nullable

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
@@ -239,9 +239,11 @@ public class BasicParameterBuilder extends ParameterBuilder {
         imp.getExt().put("prebid", Prebid.getJsonObjectForImp(mAdConfiguration));
 
         final Map<String, Set<String>> contextDataDictionary = mAdConfiguration.getContextDataDictionary();
-        if (!contextDataDictionary.isEmpty()) {
-            JSONObject data = Utils.toJson(contextDataDictionary);
-            JSONObject context = new JSONObject();
+        JSONObject data = Utils.toJson(contextDataDictionary);
+        Utils.addValue(data, "adslot", mAdConfiguration.getPbAdSlot());
+        JSONObject context = new JSONObject();
+
+        if (data.length() > 0) {
             Utils.addValue(context, "data", data);
             imp.getExt().put("context", context);
         }

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/sdk/PrebidRenderingSettings.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/sdk/PrebidRenderingSettings.java
@@ -29,7 +29,12 @@ import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
 import org.prebid.mobile.rendering.utils.helpers.AppInfoManager;
 import org.prebid.mobile.rendering.utils.logger.LogUtil;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class PrebidRenderingSettings {
     private static final String TAG = PrebidRenderingSettings.class.getSimpleName();
@@ -92,6 +97,9 @@ public class PrebidRenderingSettings {
     private static Host sBidServerHost = Host.CUSTOM;
     private static String sAccountId;
 
+    private static String sStoredAuctionResponse;
+    private static final Map<String, String> sStoredBidResponseMap = new LinkedHashMap<>();
+
     private static int sConnectionTimeout = BaseNetworkTask.TIMEOUT_DEFAULT;
 
     private static boolean sIsSdkInitialized = false;
@@ -106,7 +114,7 @@ public class PrebidRenderingSettings {
      */
 
     public static void initializeSDK(Context context, final SdkInitListener sdkInitListener)
-            throws AdException {
+    throws AdException {
         Log.d(TAG, "Initializing Prebid Rendering SDK");
         if (context == null) {
             throw new AdException(AdException.INIT_ERROR, "Prebid Rendering SDK initialization failed. Context is null");
@@ -174,6 +182,28 @@ public class PrebidRenderingSettings {
 
     public static void setAccountId(String accountId) {
         sAccountId = accountId;
+    }
+
+    public static void setStoredAuctionResponse(String storedAuctionResponse) {
+        sStoredAuctionResponse = storedAuctionResponse;
+    }
+
+    @Nullable
+    public static String getStoredAuctionResponse() {
+        return sStoredAuctionResponse;
+    }
+
+    public static void addStoredBidResponse(String bidder, String responseId) {
+        sStoredBidResponseMap.put(bidder, responseId);
+    }
+
+    public static void clearStoredBidResponses() {
+        sStoredBidResponseMap.clear();
+    }
+
+    @NonNull
+    public static Map<String, String> getStoredBidResponseMap() {
+        return sStoredBidResponseMap;
     }
 
     /**

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/display/BaseAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/display/BaseAdUnitTest.java
@@ -229,6 +229,13 @@ public class BaseAdUnitTest {
         assertEquals(expectedSet, mBaseAdUnit.getContextKeywordsSet());
     }
 
+    @Test
+    public void setPbAdSlot_EqualsGetPbAdSlot() {
+        final String expected = "12345";
+        mBaseAdUnit.setPbAdSlot(expected);
+        assertEquals(expected, mBaseAdUnit.getPbAdSlot());
+    }
+
     private BaseAdUnit createAdUnit(String configId) {
         BaseAdUnit baseAdUnit = new BaseAdUnit(mContext, configId, mMockAdSize) {
             @Override

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/parallel/BannerViewTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/parallel/BannerViewTest.java
@@ -499,6 +499,13 @@ public class BannerViewTest {
         assertEquals(BannerAdPosition.UNKNOWN, mBannerView.getAdPosition());
     }
 
+    @Test
+    public void setPbAdSlot_EqualsGetPbAdSlot() {
+        final String expected = "12345";
+        mBannerView.setPbAdSlot(expected);
+        assertEquals(expected, mBannerView.getPbAdSlot());
+    }
+
     private BidRequesterListener getBidRequesterListener() {
         try {
             return (BidRequesterListener) WhiteBox.field(BannerView.class, "mBidRequesterListener").get(mBannerView);

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/parallel/BaseInterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/bidding/parallel/BaseInterstitialAdUnitTest.java
@@ -19,8 +19,6 @@ package org.prebid.mobile.rendering.bidding.parallel;
 import android.app.Activity;
 import android.content.Context;
 
-import androidx.annotation.Nullable;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +34,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import androidx.annotation.Nullable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -135,5 +135,12 @@ public class BaseInterstitialAdUnitTest {
         // add all
         mBaseInterstitialAdUnit.addContextKeywords(expectedSet);
         assertEquals(expectedSet, mBaseInterstitialAdUnit.getContextKeywordsSet());
+    }
+
+    @Test
+    public void setPbAdSlot_EqualsGetPbAdSlot() {
+        final String expected = "12345";
+        mBaseInterstitialAdUnit.setPbAdSlot(expected);
+        assertEquals(expected, mBaseInterstitialAdUnit.getPbAdSlot());
     }
 }

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -48,6 +48,7 @@ import org.prebid.mobile.rendering.networking.targeting.Targeting;
 import org.prebid.mobile.rendering.sdk.ManagersResolver;
 import org.prebid.mobile.rendering.sdk.PrebidRenderingSettings;
 import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
+import org.prebid.mobile.rendering.utils.helpers.Utils;
 import org.prebid.mobile.test.utils.WhiteBox;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
@@ -108,6 +109,8 @@ public class BasicParameterBuilderTest {
         PrebidRenderingSettings.sendMraidSupportParams = true;
         PrebidRenderingSettings.useExternalBrowser = false;
         PrebidRenderingSettings.isCoppaEnabled = false;
+        PrebidRenderingSettings.clearStoredBidResponses();
+        PrebidRenderingSettings.setStoredAuctionResponse(null);
     }
 
     @Test
@@ -115,6 +118,9 @@ public class BasicParameterBuilderTest {
         AdConfiguration adConfiguration = new AdConfiguration();
         adConfiguration.setAdUnitIdentifierType(AdConfiguration.AdUnitIdentifierType.BANNER);
         adConfiguration.addSize(new AdSize(320, 50));
+        adConfiguration.setPbAdSlot("12345");
+        PrebidRenderingSettings.addStoredBidResponse("bidderTest", "123456");
+        PrebidRenderingSettings.setStoredAuctionResponse("storedResponse");
 
         BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
         AdRequestInput adRequestInput = new AdRequestInput();
@@ -457,6 +463,16 @@ public class BasicParameterBuilderTest {
         }
         else {
             imp.banner = getExpectedBannerImpValues(imp, adConfiguration);
+        }
+
+        final String pbAdSlot = adConfiguration.getPbAdSlot();
+        if (pbAdSlot != null) {
+            JSONObject context = new JSONObject();
+            JSONObject data = new JSONObject();
+            Utils.addValue(data, "adslot", pbAdSlot);
+            Utils.addValue(context, "data", data);
+
+            imp.getExt().put("context", context);
         }
 
         return imp;

--- a/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/sdk/PrebidRenderingSettingsTest.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/test/java/org/prebid/mobile/rendering/sdk/PrebidRenderingSettingsTest.java
@@ -34,8 +34,11 @@ import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -64,7 +67,8 @@ public class PrebidRenderingSettingsTest {
 
     @After
     public void tearDown() throws Exception {
-
+        PrebidRenderingSettings.setStoredAuctionResponse(null);
+        PrebidRenderingSettings.clearStoredBidResponses();
     }
 
     @Test
@@ -116,5 +120,28 @@ public class PrebidRenderingSettingsTest {
         PrebidRenderingSettings.setBidServerHost(host);
 
         assertEquals(host, PrebidRenderingSettings.getBidServerHost());
+    }
+
+    @Test
+    public void setStoreAuctionResponse_EqualsGetStoredAuctionResponse() {
+        final String expected = "11111";
+        PrebidRenderingSettings.setStoredAuctionResponse(expected);
+        assertEquals(expected, PrebidRenderingSettings.getStoredAuctionResponse());
+    }
+
+    @Test
+    public void addAndClearStoredBidResponseMap_ReturnExpectedResult() {
+        Map<String, String> expectedMap = new LinkedHashMap<>();
+        expectedMap.put("bidder1", "1111");
+        expectedMap.put("bidder2", "2222");
+
+        PrebidRenderingSettings.addStoredBidResponse("bidder1", "1111");
+        PrebidRenderingSettings.addStoredBidResponse("bidder2", "2222");
+
+        assertEquals(expectedMap, PrebidRenderingSettings.getStoredBidResponseMap());
+
+        PrebidRenderingSettings.clearStoredBidResponses();
+
+        assertTrue(PrebidRenderingSettings.getStoredBidResponseMap().isEmpty());
     }
 }


### PR DESCRIPTION
This PR is created as a result of request parameter sync mentioned in this comment: https://github.com/prebid/prebid-mobile-android/pull/259#issuecomment-846111755
"startdelay" - is not applicable to the current version of Rendering module as we don't support instream video ads.
"atype" & "uids" - we support setting "eids" (which contains "uids" & "adtype") as a JSONArray via `Targeting.setEids()`.

Support for: "adslot", "storedauctionresponse", "storedbidresponse" was added to the API and requests.

Prebid privacy policy logic:
```
"Prebid_COPPA"
"Prebid_GDPR"
"Prebid_GDPR_consent_strings"
"Prebid_GDPR_PurposeConsents"
```
Will be discussed separately (start of discussion: https://github.com/prebid/prebid-mobile-android/pull/259#issuecomment-846977087). 

**Commit details**
chore(request):
- Added "adslot" to imp.ext.context.data.adslot
- Added API for setting pbAdSlot
- Added "storedauctionresponse" and "storedbidresponse" support and API
- Added unit tests