### PR TITLE
MOBILE-7128: Add switcher to demo app for GDPR compliance

### DIFF
--- a/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/pages/HomePage.java
+++ b/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/pages/HomePage.java
@@ -18,17 +18,17 @@ package org.prebid.mobile.renderingtestapp.uiAutomator.pages;
 
 import android.util.Log;
 
-import androidx.test.uiautomator.By;
-import androidx.test.uiautomator.BySelector;
-import androidx.test.uiautomator.UiDevice;
-import androidx.test.uiautomator.UiObject2;
-import androidx.test.uiautomator.Until;
-
 import org.prebid.mobile.renderingtestapp.BuildConfig;
 import org.prebid.mobile.renderingtestapp.uiAutomator.pages.factory.BannerPageFactory;
 import org.prebid.mobile.renderingtestapp.uiAutomator.pages.factory.InterstitialPageFactory;
 import org.prebid.mobile.renderingtestapp.uiAutomator.pages.factory.MraidPageFactory;
 import org.prebid.mobile.renderingtestapp.uiAutomator.pages.factory.NativePageFactory;
+
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.Until;
 
 public class HomePage extends BasePage {
 
@@ -37,11 +37,13 @@ public class HomePage extends BasePage {
         static BySelector dismissDialog = By.res(TAG, "dismiss_button");
         static BySelector allowButton = By.res("com.android.packageinstaller", "permission_allow_button");
         static BySelector mockServerSwitch = By.res(TAG, "switchUseMock");
+        static BySelector gdprSwitch = By.res(TAG, "switchEnableGdpr");
     }
 
     public HomePage(UiDevice device) {
         super(device);
         setUseMockServer(BuildConfig.FLAVOR == "mock");
+        setUseGdpr(false);
     }
 
     public void dismissWelcomeDialog() {
@@ -88,10 +90,19 @@ public class HomePage extends BasePage {
     }
 
     public HomePage setUseMockServer(boolean state) {
-        UiObject2 switchUiObject = device.wait(Until.findObject(Locators.mockServerSwitch), 2000);
+        changeSwitchState(state, Locators.mockServerSwitch);
+        return this;
+    }
+
+    public HomePage setUseGdpr(boolean state) {
+        changeSwitchState(state, Locators.gdprSwitch);
+        return this;
+    }
+
+    private void changeSwitchState(boolean state, BySelector selector) {
+        UiObject2 switchUiObject = device.wait(Until.findObject(selector), 2000);
         if (switchUiObject != null && switchUiObject.isChecked() != state) {
             switchUiObject.click();
         }
-        return this;
     }
 }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingFragment.kt
@@ -23,10 +23,12 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
+import androidx.preference.PreferenceManager
 import kotlinx.android.synthetic.main.fragment_main.*
 import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.data.DemoItem
 import org.prebid.mobile.renderingtestapp.utils.BaseFragment
+import org.prebid.mobile.renderingtestapp.utils.GdprHelper
 import org.prebid.mobile.renderingtestapp.utils.SegmentAdapterReImpl
 import org.prebid.mobile.renderingtestapp.utils.adapters.DemoItemClickListener
 import org.prebid.mobile.renderingtestapp.utils.adapters.DemoListAdapter
@@ -50,6 +52,7 @@ class HeaderBiddingFragment : BaseFragment() {
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         initViewModel()
         initMockSwitch()
+        initGdprSwitch()
         initIntegrationsSegmentControl(view)
         initAdCategoriesSegmentControl(view)
         initListView()
@@ -58,9 +61,13 @@ class HeaderBiddingFragment : BaseFragment() {
     }
 
     private fun initViewModel() {
-        val viewModelFactory = HeaderBiddingViewModelFactory(resources.getStringArray(integrationCategoriesArrayId),
-                resources.getStringArray(adCategoriesArrayId))
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[HeaderBiddingViewModel::class.java]
+        val viewModelFactory = HeaderBiddingViewModelFactory(
+            resources.getStringArray(integrationCategoriesArrayId),
+            resources.getStringArray(adCategoriesArrayId),
+            GdprHelper(PreferenceManager.getDefaultSharedPreferences(requireContext()))
+        )
+        viewModel =
+            ViewModelProviders.of(this, viewModelFactory)[HeaderBiddingViewModel::class.java]
         viewModel.navigateToDemoExample.observe(this, Observer {
             it?.let {
                 searchDemos.clearFocus()
@@ -143,6 +150,13 @@ class HeaderBiddingFragment : BaseFragment() {
         switchUseMock.isChecked = viewModel.isMockServer()
         switchUseMock.setOnCheckedChangeListener { _, isChecked ->
             viewModel.onMockSwitchStateChanged(isChecked)
+        }
+    }
+
+    private fun initGdprSwitch() {
+        switchEnableGdpr.isChecked = viewModel.isSubjectToGdpr()
+        switchEnableGdpr.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.onGdprSwitchStateChanged(isChecked)
         }
     }
 

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt
@@ -23,11 +23,13 @@ import org.prebid.mobile.renderingtestapp.data.DemoItem
 import org.prebid.mobile.renderingtestapp.data.Tag
 import org.prebid.mobile.renderingtestapp.utils.ConfigurationViewSettings
 import org.prebid.mobile.renderingtestapp.utils.DemoItemProvider
+import org.prebid.mobile.renderingtestapp.utils.GdprHelper
 import org.prebid.mobile.renderingtestapp.utils.SourcePicker
 
 class HeaderBiddingViewModel(
         private val integrationCategories: Array<String>,
-        private val adCategories: Array<String>
+        private val adCategories: Array<String>,
+        private val gdprHelper: GdprHelper
 ) : ViewModel() {
 
     private var demoItemList: MutableList<DemoItem> = DemoItemProvider.getDemoList()
@@ -78,6 +80,14 @@ class HeaderBiddingViewModel(
 
     fun isMockServer(): Boolean {
         return SourcePicker.useMockServer
+    }
+
+    fun isSubjectToGdpr(): Boolean {
+        return gdprHelper.isGdprEnabled()
+    }
+
+    fun onGdprSwitchStateChanged(isChecked: Boolean) {
+        gdprHelper.changeGdprState(isChecked)
     }
 
     fun onMockSwitchStateChanged(isChecked: Boolean) {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModelFactory.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModelFactory.kt
@@ -18,12 +18,16 @@ package org.prebid.mobile.renderingtestapp.plugplay.bidding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import org.prebid.mobile.renderingtestapp.utils.GdprHelper
 
-class HeaderBiddingViewModelFactory(private val integrationCategories: Array<String>,
-                                    private val adCategories: Array<String>) : ViewModelProvider.Factory {
+class HeaderBiddingViewModelFactory(
+    private val integrationCategories: Array<String>,
+    private val adCategories: Array<String>,
+    private val gdprHelper: GdprHelper
+) : ViewModelProvider.Factory {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(HeaderBiddingViewModel::class.java)) {
-            return HeaderBiddingViewModel(integrationCategories, adCategories) as T
+            return HeaderBiddingViewModel(integrationCategories, adCategories, gdprHelper) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/GdprHelper.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/GdprHelper.kt
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2018-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.renderingtestapp.utils
+
+import android.content.SharedPreferences
+
+class GdprHelper(private val defaultPreferences: SharedPreferences) {
+
+    companion object {
+        private const val GDPR_APPLIES = "IABTCF_gdprApplies"
+        private const val CMP_SDK_ID = "IABTCF_CmpSdkID"
+    }
+
+    fun changeGdprState(isEnabled: Boolean) {
+        if (isEnabled) {
+            defaultPreferences.edit().remove(GDPR_APPLIES).apply()
+            defaultPreferences.edit().remove(CMP_SDK_ID).apply()
+        } else {
+            //Set fake params to disable GDPR
+            defaultPreferences.edit().putInt(GDPR_APPLIES, 0).apply()
+            defaultPreferences.edit().putInt(CMP_SDK_ID, 123).apply()
+        }
+    }
+
+    fun isGdprEnabled(): Boolean {
+        val defaultValue = -1
+        return defaultPreferences.getInt(GDPR_APPLIES, defaultValue) == 1
+                || defaultPreferences.getInt(CMP_SDK_ID, defaultValue) == defaultValue
+    }
+}

--- a/Example/PrebidInternalTestApp/src/main/res/layout/fragment_main.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/layout/fragment_main.xml
@@ -44,19 +44,51 @@
     </FrameLayout>
 
 
+    <ToggleButton
+        android:id="@+id/toggleConfigurationButton"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/selector_toggle_background"
+        android:gravity="center"
+        android:includeFontPadding="false"
+        android:textOff=""
+        android:textOn=""
+        android:textSize="0sp"
+        app:layout_constraintBottom_toBottomOf="@+id/switchUseMock"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/switchEnableGdpr"
+        app:layout_constraintTop_toTopOf="@+id/switchUseMock" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchEnableGdpr"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="5dp"
+        android:text="@string/text_switch_enable_gdpr"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/switchUseMock"
+        app:layout_constraintEnd_toStartOf="@+id/toggleConfigurationButton"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/switchUseMock"
+        app:layout_constraintTop_toTopOf="@+id/switchUseMock"
+        app:switchPadding="18dp" />
+
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/switchUseMock"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:layout_marginStart="8dp"
+        android:padding="5dp"
         android:text="@string/text_switch_use_mock"
         android:textSize="14sp"
         android:textStyle="bold"
-        android:padding="5dp"
         app:layout_constraintBottom_toTopOf="@+id/listDemos"
-        app:layout_constraintEnd_toStartOf="@+id/toggleConfigurationButton"
-        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toStartOf="@+id/switchEnableGdpr"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/adCategoriesSegmentedControl"
         app:switchPadding="18dp" />
@@ -71,27 +103,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/switchUseMock" />
-
-    <segmented_control.widget.custom.android.com.segmentedcontrol.SegmentedControl
-        android:id="@+id/integrationsSegmentedControl"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
-        android:layout_marginEnd="6dp"
-        android:layout_marginLeft="6dp"
-        android:layout_marginRight="6dp"
-        android:layout_marginStart="6dp"
-        app:columnCount="6"
-        app:distributeEvenly="true"
-        app:layout_constraintBottom_toTopOf="@+id/adCategoriesSegmentedControl"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/frameLayout"
-        app:radius="6dp"
-        app:selectedBackgroundColor="@color/action_bar_bkg"
-        app:textVerticalPadding="6dp">
-
-    </segmented_control.widget.custom.android.com.segmentedcontrol.SegmentedControl>
 
     <segmented_control.widget.custom.android.com.segmentedcontrol.SegmentedControl
         android:id="@+id/adCategoriesSegmentedControl"
@@ -114,19 +125,24 @@
 
     </segmented_control.widget.custom.android.com.segmentedcontrol.SegmentedControl>
 
-    <ToggleButton
-        android:id="@+id/toggleConfigurationButton"
+    <segmented_control.widget.custom.android.com.segmentedcontrol.SegmentedControl
+        android:id="@+id/integrationsSegmentedControl"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginEnd="8dp"
-        android:background="@drawable/selector_toggle_background"
-        android:gravity="center"
-        android:includeFontPadding="false"
-        android:textOff=""
-        android:textOn=""
-        android:textSize="0sp"
-        app:layout_constraintBottom_toBottomOf="@+id/switchUseMock"
-        app:layout_constraintDimensionRatio="1:1"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginLeft="6dp"
+        android:layout_marginRight="6dp"
+        android:layout_marginStart="6dp"
+        app:columnCount="6"
+        app:distributeEvenly="true"
+        app:layout_constraintBottom_toTopOf="@+id/adCategoriesSegmentedControl"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/switchUseMock" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/frameLayout"
+        app:radius="6dp"
+        app:selectedBackgroundColor="@color/action_bar_bkg"
+        app:textVerticalPadding="6dp">
+
+    </segmented_control.widget.custom.android.com.segmentedcontrol.SegmentedControl>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
 
     <string name="label_auid">AdUnitId: %1$s</string>
     <string name="text_switch_use_mock">Use Mock Server</string>
+    <string name="text_switch_enable_gdpr">Enable GDPR</string>
 
     <string name="dialog_configurator_title">Configure the Ad</string>
     <string name="dialog_configurator_load">Load the ad</string>


### PR DESCRIPTION
chore:
- Added gdpr helper class to work with updating iab values
- Added switch to change state of GDPR
- Disabling gdpr in ui tests

Screenshot showing how it looks like: 
<img width="374" alt="Screenshot 2021-08-05 at 16 11 21" src="https://user-images.githubusercontent.com/79995965/128355789-58b3713d-859f-4a3d-af44-ea6385125c3e.png">
